### PR TITLE
feat: add privacy policy page

### DIFF
--- a/src/routes/canada-days-privacy/+page.svelte
+++ b/src/routes/canada-days-privacy/+page.svelte
@@ -1,0 +1,73 @@
+<svelte:head>
+	<title>Privacy Policy — Canada Days</title>
+	<meta name="description" content="Privacy policy for the Canada Days iOS app." />
+</svelte:head>
+
+<article class="flex flex-col gap-6">
+	<div>
+		<h1 class="text-3xl font-bold mb-1">Privacy Policy</h1>
+		<p class="text-sm opacity-60">Canada Days — iOS App</p>
+		<p class="text-sm opacity-60">Last updated: January 30, 2026</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Overview</h2>
+		<p>
+			Canada Days helps you track physical presence in Canada for citizenship eligibility.
+			Your privacy is important — the app is designed to keep your data on your devices.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Data Collection</h2>
+		<p>Canada Days does <strong>not</strong> collect, transmit, or share any personal data with the developer or third parties.</p>
+		<p class="mt-2">All data stays on your device and, if enabled, in your personal iCloud account.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">What the App Stores</h2>
+		<ul class="list-disc list-inside ml-2 space-y-1">
+			<li><strong>Dates</strong> — your temporary residency and PR dates</li>
+			<li><strong>Trips</strong> — trip names and travel dates you enter</li>
+			<li><strong>Preferences</strong> — notification settings and onboarding state</li>
+		</ul>
+		<p class="mt-2">This data is stored locally on your device and synced to your iCloud account (if available) using Apple's iCloud Key-Value Storage. Only you can access it.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Photo Library Access</h2>
+		<p>
+			The optional Photo Scan feature requests access to your photo library to detect trips outside Canada using location metadata embedded in your photos.
+		</p>
+		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
+			<li>Photos are processed <strong>entirely on your device</strong></li>
+			<li>No photos or location data are uploaded, transmitted, or shared</li>
+			<li>You can revoke photo access at any time in Settings</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Analytics & Tracking</h2>
+		<p>The app does not include any analytics, tracking, or advertising frameworks.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Third-Party Services</h2>
+		<p>The app does not use any third-party services. The only network calls are to Apple's StoreKit for in-app purchases and iCloud for data sync — both handled entirely by Apple.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Children's Privacy</h2>
+		<p>The app is not directed at children under 13 and does not knowingly collect information from children.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Changes</h2>
+		<p>If this policy is updated, the changes will be posted on this page with an updated date.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Contact</h2>
+		<p>Questions? Reach out at <a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.</p>
+	</div>
+</article>


### PR DESCRIPTION
## Summary
- Add `/privacy` route with privacy policy for the Canada Days iOS app
- Covers: data storage, photo library access, no analytics/tracking, no third-party services

Live at: byvova.com/privacy

Resolves VOV-41

🤖 Generated with [Claude Code](https://claude.com/claude-code)