### PR TITLE
Add privacy policy page for The Shy Dock

### DIFF
--- a/src/routes/the-shy-dock-privacy/+page.svelte
+++ b/src/routes/the-shy-dock-privacy/+page.svelte
@@ -1,0 +1,66 @@
+<svelte:head>
+	<title>Privacy Policy — The Shy Dock</title>
+	<meta name="description" content="Privacy policy for The Shy Dock macOS app." />
+</svelte:head>
+
+<article class="flex flex-col gap-6">
+	<div>
+		<h1 class="text-3xl font-bold mb-1">Privacy Policy</h1>
+		<p class="text-sm opacity-60">The Shy Dock — macOS App</p>
+		<p class="text-sm opacity-60">Last updated: February 1, 2026</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Overview</h2>
+		<p>
+			The Shy Dock automatically manages your Dock visibility based on external monitor connections.
+			Your privacy is important — the app runs entirely on your Mac with no network connections.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Data Collection</h2>
+		<p>The Shy Dock does <strong>not</strong> collect, transmit, or share any personal data with the developer or third parties.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">What the App Stores</h2>
+		<ul class="list-disc list-inside ml-2 space-y-1">
+			<li><strong>Preferences</strong> — resolution threshold settings and launch-at-login state</li>
+		</ul>
+		<p class="mt-2">This data is stored locally on your Mac using UserDefaults. Nothing leaves your device.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Accessibility Permission</h2>
+		<p>
+			The app requests Accessibility permission solely to control the Dock's auto-hide setting via System Events.
+			This permission is not used for any other purpose.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Analytics & Tracking</h2>
+		<p>The app does not include any analytics, tracking, or advertising frameworks.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Third-Party Services</h2>
+		<p>The app does not use any third-party services and makes no network connections.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Children's Privacy</h2>
+		<p>The app is not directed at children under 13 and does not knowingly collect information from children.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Changes</h2>
+		<p>If this policy is updated, the changes will be posted on this page with an updated date.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Contact</h2>
+		<p>Questions? Reach out at <a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.</p>
+	</div>
+</article>


### PR DESCRIPTION
## Summary
- Added privacy policy page at `/the-shy-dock-privacy` for The Shy Dock macOS app
- Follows the same structure and styling as the existing Canada Days privacy page

## Linear Issue
Addresses VOV-46

🤖 Generated with [Claude Code](https://claude.com/claude-code)