### PR TITLE
Add French Canadian privacy policy for Canada Days

### DIFF
--- a/src/routes/canada-days-privacy-fr/+page.svelte
+++ b/src/routes/canada-days-privacy-fr/+page.svelte
@@ -1,0 +1,82 @@
+<svelte:head>
+	<title>Politique de confidentialité — Jours au Canada</title>
+	<meta name="description" content="Politique de confidentialité de l'application iOS Jours au Canada." />
+</svelte:head>
+
+<article class="flex flex-col gap-6">
+	<div>
+		<h1 class="text-3xl font-bold mb-1">Politique de confidentialité</h1>
+		<p class="text-sm opacity-60">Jours au Canada — Application iOS</p>
+		<p class="text-sm opacity-60">Dernière mise à jour : 10 février 2026</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Aperçu</h2>
+		<p>
+			Jours au Canada vous aide à suivre votre présence physique au Canada pour déterminer votre admissibilité à la citoyenneté.
+			Votre vie privée est importante — l'application est conçue pour conserver vos données sur vos appareils.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Collecte de données</h2>
+		<p>Jours au Canada ne collecte <strong>pas</strong>, ne transmet pas et ne partage pas de données personnelles identifiables avec le développeur.</p>
+		<p class="mt-2">Toutes les données saisies par l'utilisateur restent sur votre appareil et, si activé, dans votre compte iCloud personnel. L'application collecte des analyses d'utilisation anonymes comme décrit ci-dessous.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Ce que l'application stocke</h2>
+		<ul class="list-disc list-inside ml-2 space-y-1">
+			<li><strong>Dates</strong> — vos dates de résidence temporaire et de résidence permanente</li>
+			<li><strong>Voyages</strong> — les noms de voyages et les dates de déplacement que vous saisissez</li>
+			<li><strong>Préférences</strong> — paramètres de notifications et état d'intégration</li>
+		</ul>
+		<p class="mt-2">Ces données sont stockées localement sur votre appareil et synchronisées avec votre compte iCloud (si disponible) via le stockage clé-valeur iCloud d'Apple. Vous seul pouvez y accéder.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Accès à la photothèque</h2>
+		<p>
+			La fonctionnalité optionnelle de scan de photos demande l'accès à votre photothèque pour détecter les voyages hors du Canada à partir des métadonnées de localisation intégrées dans vos photos.
+		</p>
+		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
+			<li>Les photos sont traitées <strong>entièrement sur votre appareil</strong></li>
+			<li>Aucune photo ni donnée de localisation n'est téléchargée, transmise ou partagée</li>
+			<li>Vous pouvez révoquer l'accès aux photos à tout moment dans les Réglages</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Analyses et suivi</h2>
+		<p>L'application utilise <a class="underline decoration-dotted" href="https://posthog.com">PostHog</a> pour collecter des analyses d'utilisation anonymes. Cela permet de comprendre comment l'application est utilisée et de l'améliorer.</p>
+		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
+			<li>Les analyses sont <strong>anonymes</strong> — aucun nom, courriel ou information personnellement identifiable n'est collecté</li>
+			<li>Seuls des événements de base sont suivis (p. ex. compléter l'intégration, ajouter un voyage)</li>
+			<li>Aucun cadre publicitaire ni suivi publicitaire n'est utilisé</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Services tiers</h2>
+		<ul class="list-disc list-inside ml-2 space-y-1">
+			<li><strong>PostHog</strong> — analyses d'utilisation anonymes (<a class="underline decoration-dotted" href="https://posthog.com/privacy">Politique de confidentialité PostHog</a>)</li>
+			<li><strong>Apple StoreKit</strong> — achats intégrés</li>
+			<li><strong>Apple iCloud</strong> — synchronisation des données entre vos appareils</li>
+		</ul>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Confidentialité des enfants</h2>
+		<p>L'application n'est pas destinée aux enfants de moins de 13 ans et ne collecte pas sciemment d'informations auprès d'enfants.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Modifications</h2>
+		<p>Si cette politique est mise à jour, les modifications seront publiées sur cette page avec une date actualisée.</p>
+	</div>
+
+	<div>
+		<h2 class="text-xl font-semibold mb-2">Contact</h2>
+		<p>Des questions ? Écrivez-nous à <a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.</p>
+	</div>
+</article>


### PR DESCRIPTION
Adds `/canada-days-privacy-fr` — French Canadian translation of the privacy policy, needed for the App Store Connect fr-CA localization entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)