### PR TITLE
Update Days in Canada privacy policy for Android

### DIFF
--- a/src/routes/canada-days-privacy-fr/+page.svelte
+++ b/src/routes/canada-days-privacy-fr/+page.svelte
@@ -1,82 +1,194 @@
 <svelte:head>
 	<title>Politique de confidentialité — Jours au Canada</title>
-	<meta name="description" content="Politique de confidentialité de l'application iOS Jours au Canada." />
+	<meta
+		name="description"
+		content="Politique de confidentialité des applications iOS et Android Jours au Canada."
+	/>
 </svelte:head>
 
 <article class="flex flex-col gap-6">
 	<div>
-		<h1 class="text-3xl font-bold mb-1">Politique de confidentialité</h1>
-		<p class="text-sm opacity-60">Jours au Canada — Application iOS</p>
-		<p class="text-sm opacity-60">Dernière mise à jour : 10 février 2026</p>
+		<h1 class="mb-1 text-3xl font-bold">Politique de confidentialité</h1>
+		<p class="text-sm opacity-60">Jours au Canada — iOS et Android</p>
+		<p class="text-sm opacity-60">Dernière mise à jour : 23 juillet 2026</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Aperçu</h2>
+		<h2 class="mb-2 text-xl font-semibold">Aperçu</h2>
 		<p>
-			Jours au Canada vous aide à suivre votre présence physique au Canada pour déterminer votre admissibilité à la citoyenneté.
-			Votre vie privée est importante — l'application est conçue pour conserver vos données sur vos appareils.
+			Jours au Canada vous aide à estimer votre présence physique aux fins de la citoyenneté
+			canadienne. Il s'agit d'un outil pratique, et non du calculateur officiel d'IRCC ni d'un avis
+			juridique. L'application est conçue pour vous laisser le contrôle de vos dates, de vos voyages
+			et de vos photos.
 		</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Collecte de données</h2>
-		<p>Jours au Canada ne collecte <strong>pas</strong>, ne transmet pas et ne partage pas de données personnelles identifiables avec le développeur.</p>
-		<p class="mt-2">Toutes les données saisies par l'utilisateur restent sur votre appareil et, si activé, dans votre compte iCloud personnel. L'application collecte des analyses d'utilisation anonymes comme décrit ci-dessous.</p>
-	</div>
-
-	<div>
-		<h2 class="text-xl font-semibold mb-2">Ce que l'application stocke</h2>
-		<ul class="list-disc list-inside ml-2 space-y-1">
-			<li><strong>Dates</strong> — vos dates de résidence temporaire et de résidence permanente</li>
-			<li><strong>Voyages</strong> — les noms de voyages et les dates de déplacement que vous saisissez</li>
-			<li><strong>Préférences</strong> — paramètres de notifications et état d'intégration</li>
+		<h2 class="mb-2 text-xl font-semibold">Données enregistrées dans l'application</h2>
+		<ul class="ml-2 list-inside list-disc space-y-1">
+			<li><strong>Dates</strong> — dates de résidence temporaire et de résidence permanente</li>
+			<li><strong>Voyages</strong> — noms et dates de vos voyages</li>
+			<li>
+				<strong>Préférences</strong> — notifications, état d'intégration et droit d'accès acheté
+			</li>
 		</ul>
-		<p class="mt-2">Ces données sont stockées localement sur votre appareil et synchronisées avec votre compte iCloud (si disponible) via le stockage clé-valeur iCloud d'Apple. Vous seul pouvez y accéder.</p>
-	</div>
-
-	<div>
-		<h2 class="text-xl font-semibold mb-2">Accès à la photothèque</h2>
-		<p>
-			La fonctionnalité optionnelle de scan de photos demande l'accès à votre photothèque pour détecter les voyages hors du Canada à partir des métadonnées de localisation intégrées dans vos photos.
+		<p class="mt-2">
+			Sur Android, ces données sont stockées localement sur votre appareil. Sur iOS, elles sont
+			stockées localement et peuvent être synchronisées avec votre compte iCloud lorsque celui-ci
+			est disponible. Le développeur ne reçoit ni vos dates de citoyenneté ni vos voyages.
 		</p>
-		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
-			<li>Les photos sont traitées <strong>entièrement sur votre appareil</strong></li>
-			<li>Aucune photo ni donnée de localisation n'est téléchargée, transmise ou partagée</li>
-			<li>Vous pouvez révoquer l'accès aux photos à tout moment dans les Réglages</li>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Photothèque et métadonnées de localisation</h2>
+		<p>
+			La fonction optionnelle d'analyse de photos demande l'accès à votre photothèque pour
+			rechercher des voyages à l'aide des métadonnées de localisation intégrées aux photos.
+		</p>
+		<ul class="mt-2 ml-2 list-inside list-disc space-y-1">
+			<li>
+				Les photos sont analysées sur votre appareil et ne sont pas téléversées au développeur.
+			</li>
+			<li>
+				Les coordonnées intégrées servent à déterminer si une photo a été prise hors du Canada.
+			</li>
+			<li>
+				Sur Android, une coordonnée peut être transmise au service de géocodage du système afin de
+				suggérer un nom de destination lisible. La photo elle-même n'est pas transmise.
+			</li>
+			<li>Vous pouvez retirer l'accès aux photos à tout moment dans les réglages du système.</li>
 		</ul>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Analyses et suivi</h2>
-		<p>L'application utilise <a class="underline decoration-dotted" href="https://posthog.com">PostHog</a> pour collecter des analyses d'utilisation anonymes. Cela permet de comprendre comment l'application est utilisée et de l'améliorer.</p>
-		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
-			<li>Les analyses sont <strong>anonymes</strong> — aucun nom, courriel ou information personnellement identifiable n'est collecté</li>
-			<li>Seuls des événements de base sont suivis (p. ex. compléter l'intégration, ajouter un voyage)</li>
-			<li>Aucun cadre publicitaire ni suivi publicitaire n'est utilisé</li>
+		<h2 class="mb-2 text-xl font-semibold">Analyses anonymes</h2>
+		<p>
+			L'application utilise <a class="underline decoration-dotted" href="https://posthog.com"
+				>PostHog</a
+			>
+			pour comprendre l'utilisation de base du produit et l'améliorer. Les événements peuvent inclure
+			la fin de l'intégration, l'ajout d'un voyage, l'ouverture de l'analyse de photos ou la réalisation
+			d'un achat.
+		</p>
+		<ul class="mt-2 ml-2 list-inside list-disc space-y-1">
+			<li>
+				Aucun nom, courriel, date de citoyenneté, date ou nom de voyage, photo ou coordonnée de
+				photo n'est envoyé à PostHog.
+			</li>
+			<li>
+				PostHog reçoit un identifiant d'application aléatoire ainsi que des renseignements de base
+				sur l'application, l'appareil, le système et le réseau.
+			</li>
+			<li>
+				Nous n'utilisons ni reprise de session, ni suivi publicitaire, ni profil personnalisé.
+			</li>
 		</ul>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Services tiers</h2>
-		<ul class="list-disc list-inside ml-2 space-y-1">
-			<li><strong>PostHog</strong> — analyses d'utilisation anonymes (<a class="underline decoration-dotted" href="https://posthog.com/privacy">Politique de confidentialité PostHog</a>)</li>
-			<li><strong>Apple StoreKit</strong> — achats intégrés</li>
-			<li><strong>Apple iCloud</strong> — synchronisation des données entre vos appareils</li>
+		<h2 class="mb-2 text-xl font-semibold">Commentaires facultatifs</h2>
+		<p>
+			Si vous choisissez de répondre au sondage dans l'application, vos réponses oui/non et le texte
+			que vous écrivez sont transmis de façon sécurisée au service de commentaires du développeur.
+			Celui-ci transmet le message à une conversation Telegram privée utilisée pour examiner les
+			commentaires. Les commentaires n'incluent ni vos dates de citoyenneté, ni vos voyages, ni vos
+			photos, ni votre identifiant PostHog.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Achats</h2>
+		<p>
+			Les achats intégrés sont traités par l'App Store d'Apple ou Google Play. L'application reçoit
+			l'état de l'achat et du droit d'accès, mais pas les détails complets de votre carte.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Fournisseurs de services et partage</h2>
+		<p>
+			Nous ne vendons pas les données personnelles et ne les partageons pas à des fins
+			publicitaires. L'application utilise :
+		</p>
+		<ul class="mt-2 ml-2 list-inside list-disc space-y-1">
+			<li>
+				<strong>PostHog</strong> — analyse du produit (<a
+					class="underline decoration-dotted"
+					href="https://posthog.com/privacy">politique</a
+				>)
+			</li>
+			<li>
+				<strong>Telegram</strong> — traitement des commentaires facultatifs (<a
+					class="underline decoration-dotted"
+					href="https://telegram.org/privacy">politique</a
+				>)
+			</li>
+			<li>
+				<strong>Apple</strong> — StoreKit, iCloud sur iOS et services du système (<a
+					class="underline decoration-dotted"
+					href="https://www.apple.com/ca/fr/legal/privacy/">politique</a
+				>)
+			</li>
+			<li>
+				<strong>Google</strong> — facturation Google Play et services du système Android (<a
+					class="underline decoration-dotted"
+					href="https://policies.google.com/privacy?hl=fr-CA">politique</a
+				>)
+			</li>
+		</ul>
+		<p class="mt-2">
+			Ces fournisseurs peuvent traiter des données à l'extérieur de votre pays selon leurs propres
+			politiques.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Conservation, suppression et choix</h2>
+		<ul class="ml-2 list-inside list-disc space-y-1">
+			<li>
+				Vous pouvez supprimer les données locales en effaçant les éléments dans l'application ou en
+				la désinstallant.
+			</li>
+			<li>
+				Les utilisateurs iOS peuvent gérer les données synchronisées dans les réglages iCloud.
+			</li>
+			<li>
+				Les analyses et commentaires facultatifs sont conservés uniquement aussi longtemps qu'il est
+				raisonnablement nécessaire pour exploiter, soutenir et améliorer l'application.
+			</li>
+			<li>
+				Vous pouvez demander l'accès ou la suppression des analyses ou commentaires à l'adresse
+				ci-dessous. Ajoutez tout renseignement permettant de retrouver les données.
+			</li>
 		</ul>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Confidentialité des enfants</h2>
-		<p>L'application n'est pas destinée aux enfants de moins de 13 ans et ne collecte pas sciemment d'informations auprès d'enfants.</p>
+		<h2 class="mb-2 text-xl font-semibold">Sécurité</h2>
+		<p>
+			Les données envoyées à PostHog, au service de commentaires, à Apple ou à Google sont chiffrées
+			en transit au moyen de HTTPS/TLS. Aucune méthode ne peut être garantie totalement sécuritaire.
+		</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Modifications</h2>
-		<p>Si cette politique est mise à jour, les modifications seront publiées sur cette page avec une date actualisée.</p>
+		<h2 class="mb-2 text-xl font-semibold">Confidentialité des enfants</h2>
+		<p>
+			L'application ne vise pas les enfants de moins de 13 ans et ne recueille pas sciemment leurs
+			renseignements personnels.
+		</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Contact</h2>
-		<p>Des questions ? Écrivez-nous à <a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.</p>
+		<h2 class="mb-2 text-xl font-semibold">Modifications</h2>
+		<p>Les mises à jour seront publiées sur cette page avec une nouvelle date.</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Contact</h2>
+		<p>
+			Questions ou demandes relatives à la confidentialité :
+			<a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.
+		</p>
 	</div>
 </article>

--- a/src/routes/canada-days-privacy/+page.svelte
+++ b/src/routes/canada-days-privacy/+page.svelte
@@ -1,82 +1,171 @@
 <svelte:head>
-	<title>Privacy Policy — Canada Days</title>
-	<meta name="description" content="Privacy policy for the Canada Days iOS app." />
+	<title>Privacy Policy — Days in Canada</title>
+	<meta name="description" content="Privacy policy for the Days in Canada iOS and Android apps." />
 </svelte:head>
 
 <article class="flex flex-col gap-6">
 	<div>
-		<h1 class="text-3xl font-bold mb-1">Privacy Policy</h1>
-		<p class="text-sm opacity-60">Canada Days — iOS App</p>
-		<p class="text-sm opacity-60">Last updated: February 10, 2026</p>
+		<h1 class="mb-1 text-3xl font-bold">Privacy Policy</h1>
+		<p class="text-sm opacity-60">Days in Canada — iOS and Android</p>
+		<p class="text-sm opacity-60">Last updated: July 23, 2026</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Overview</h2>
+		<h2 class="mb-2 text-xl font-semibold">Overview</h2>
 		<p>
-			Canada Days helps you track physical presence in Canada for citizenship eligibility.
-			Your privacy is important — the app is designed to keep your data on your devices.
+			Days in Canada helps you estimate physical-presence credit toward Canadian citizenship. It is
+			a convenience tool, not an official IRCC calculator or legal advice. The app is designed to
+			keep your dates, trips, and photos under your control.
 		</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Data Collection</h2>
-		<p>Canada Days does <strong>not</strong> collect, transmit, or share any personally identifiable data with the developer.</p>
-		<p class="mt-2">All user-entered data stays on your device and, if enabled, in your personal iCloud account. The app collects anonymous usage analytics as described below.</p>
-	</div>
-
-	<div>
-		<h2 class="text-xl font-semibold mb-2">What the App Stores</h2>
-		<ul class="list-disc list-inside ml-2 space-y-1">
-			<li><strong>Dates</strong> — your temporary residency and PR dates</li>
-			<li><strong>Trips</strong> — trip names and travel dates you enter</li>
-			<li><strong>Preferences</strong> — notification settings and onboarding state</li>
+		<h2 class="mb-2 text-xl font-semibold">Data You Store in the App</h2>
+		<ul class="ml-2 list-inside list-disc space-y-1">
+			<li><strong>Dates</strong> — temporary-residency and permanent-resident dates</li>
+			<li><strong>Trips</strong> — trip names and travel dates</li>
+			<li>
+				<strong>Preferences</strong> — notification settings, onboarding state, and purchase entitlement
+			</li>
 		</ul>
-		<p class="mt-2">This data is stored locally on your device and synced to your iCloud account (if available) using Apple's iCloud Key-Value Storage. Only you can access it.</p>
-	</div>
-
-	<div>
-		<h2 class="text-xl font-semibold mb-2">Photo Library Access</h2>
-		<p>
-			The optional Photo Scan feature requests access to your photo library to detect trips outside Canada using location metadata embedded in your photos.
+		<p class="mt-2">
+			On Android, this data is stored locally on your device. On iOS, it is stored locally and may
+			sync through your personal iCloud account when iCloud is available. The developer does not
+			receive your citizenship dates or trip records.
 		</p>
-		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
-			<li>Photos are processed <strong>entirely on your device</strong></li>
-			<li>No photos or location data are uploaded, transmitted, or shared</li>
-			<li>You can revoke photo access at any time in Settings</li>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Photo Library and Location Metadata</h2>
+		<p>
+			The optional Photo Scan feature requests photo-library access to look for trips using location
+			metadata embedded in your photos.
+		</p>
+		<ul class="mt-2 ml-2 list-inside list-disc space-y-1">
+			<li>Photos are analyzed on your device and are not uploaded to the developer.</li>
+			<li>Embedded coordinates are used to decide whether a photo was taken outside Canada.</li>
+			<li>
+				On Android, a coordinate may be sent to the device's system geocoding service to suggest a
+				readable destination name. The photo itself is not sent.
+			</li>
+			<li>You can revoke photo access at any time in system Settings.</li>
 		</ul>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Analytics & Tracking</h2>
-		<p>The app uses <a class="underline decoration-dotted" href="https://posthog.com">PostHog</a> to collect anonymous usage analytics. This helps understand how the app is used and improve it.</p>
-		<ul class="list-disc list-inside ml-2 mt-2 space-y-1">
-			<li>Analytics are <strong>anonymous</strong> — no names, emails, or personally identifiable information is collected</li>
-			<li>Only basic events are tracked (e.g. completing onboarding, adding a trip)</li>
-			<li>No advertising frameworks or ad tracking are used</li>
+		<h2 class="mb-2 text-xl font-semibold">Anonymous Analytics</h2>
+		<p>
+			The app uses <a class="underline decoration-dotted" href="https://posthog.com">PostHog</a>
+			to understand basic product usage and improve the app. Events can include completing onboarding,
+			adding a trip, opening Photo Scan, and completing a purchase.
+		</p>
+		<ul class="mt-2 ml-2 list-inside list-disc space-y-1">
+			<li>
+				No name, email address, citizenship date, trip date, trip name, photo, or photo coordinate
+				is sent to PostHog.
+			</li>
+			<li>
+				PostHog receives a random app identifier plus basic app, device, operating-system, and
+				network information.
+			</li>
+			<li>Session replay, advertising tracking, and personalized profiles are not used.</li>
 		</ul>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Third-Party Services</h2>
-		<ul class="list-disc list-inside ml-2 space-y-1">
-			<li><strong>PostHog</strong> — anonymous usage analytics (<a class="underline decoration-dotted" href="https://posthog.com/privacy">PostHog Privacy Policy</a>)</li>
-			<li><strong>Apple StoreKit</strong> — in-app purchases</li>
-			<li><strong>Apple iCloud</strong> — data sync across your devices</li>
+		<h2 class="mb-2 text-xl font-semibold">Optional Feedback</h2>
+		<p>
+			If you choose to answer the in-app feedback survey, your yes/no answers and any text you write
+			are sent securely to the developer's feedback service. The service forwards the message to a
+			private Telegram chat used by the developer to review feedback. Feedback does not include your
+			citizenship dates, trips, photos, or PostHog identifier.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Purchases</h2>
+		<p>
+			In-app purchases are processed by Apple App Store or Google Play. The app receives purchase
+			and entitlement status but does not receive your full payment-card details.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Service Providers and Sharing</h2>
+		<p>We do not sell personal data or share it for advertising. The app uses:</p>
+		<ul class="mt-2 ml-2 list-inside list-disc space-y-1">
+			<li>
+				<strong>PostHog</strong> — product analytics (<a
+					class="underline decoration-dotted"
+					href="https://posthog.com/privacy">privacy policy</a
+				>)
+			</li>
+			<li>
+				<strong>Telegram</strong> — processing optional feedback (<a
+					class="underline decoration-dotted"
+					href="https://telegram.org/privacy">privacy policy</a
+				>)
+			</li>
+			<li>
+				<strong>Apple</strong> — StoreKit, iCloud on iOS, and system services (<a
+					class="underline decoration-dotted"
+					href="https://www.apple.com/legal/privacy/">privacy policy</a
+				>)
+			</li>
+			<li>
+				<strong>Google</strong> — Google Play Billing and Android system services (<a
+					class="underline decoration-dotted"
+					href="https://policies.google.com/privacy">privacy policy</a
+				>)
+			</li>
+		</ul>
+		<p class="mt-2">
+			These providers may process data outside your country under their own policies.
+		</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Retention, Deletion, and Your Choices</h2>
+		<ul class="ml-2 list-inside list-disc space-y-1">
+			<li>You can delete local app data by deleting entries in the app or uninstalling it.</li>
+			<li>iOS users can manage synced app data through their iCloud settings.</li>
+			<li>
+				Analytics and optional feedback are retained only as reasonably necessary to operate,
+				support, and improve the app.
+			</li>
+			<li>
+				You may request access to or deletion of analytics or feedback data by emailing the address
+				below. Include any details that can help locate the data.
+			</li>
 		</ul>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Children's Privacy</h2>
-		<p>The app is not directed at children under 13 and does not knowingly collect information from children.</p>
+		<h2 class="mb-2 text-xl font-semibold">Security</h2>
+		<p>
+			Data sent to PostHog, the feedback service, Apple, or Google is encrypted in transit using
+			HTTPS/TLS. No transmission or storage method can be guaranteed completely secure.
+		</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Changes</h2>
-		<p>If this policy is updated, the changes will be posted on this page with an updated date.</p>
+		<h2 class="mb-2 text-xl font-semibold">Children's Privacy</h2>
+		<p>
+			The app is not directed at children under 13 and does not knowingly collect their personal
+			information.
+		</p>
 	</div>
 
 	<div>
-		<h2 class="text-xl font-semibold mb-2">Contact</h2>
-		<p>Questions? Reach out at <a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.</p>
+		<h2 class="mb-2 text-xl font-semibold">Changes</h2>
+		<p>Updates will be posted on this page with a revised date.</p>
+	</div>
+
+	<div>
+		<h2 class="mb-2 text-xl font-semibold">Contact</h2>
+		<p>
+			Questions or privacy requests:
+			<a class="underline decoration-dotted" href="mailto:vovawed@gmail.com">vovawed@gmail.com</a>.
+		</p>
 	</div>
 </article>


### PR DESCRIPTION
## Summary
- cover both iOS and Android data handling
- document PostHog analytics, optional feedback, purchases, and Android system geocoding
- add retention, deletion-request, security, and service-provider disclosures in English and Canadian French

## Verification
- `npm run check`
- `npm run build`
- targeted Prettier check for both privacy pages