### PR TITLE
Move byvova.com analytics to its PostHog project

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -5,9 +5,10 @@ export const prerender = true;
 
 export const load = async () => {
 	if (browser) {
-		posthog.init('phc_VJrwFwDRz9fNGqZWL5iak91Sk2EdONawdQX1WEGkA6R', {
+		posthog.init('phc_vmyGKk9d2D9GzpJZH6p5YWW67cP4Qnndt2miMWejurwi', {
 			api_host: 'https://pineapple.byvova.com',
 			defaults: '2026-01-30'
 		});
+		posthog.register({ project: 'byvova.com' });
 	}
 };


### PR DESCRIPTION
## Summary

- Send byvova.com analytics to its new PostHog project.
- Tag its events as `byvova.com`.

## Validation

- `pnpm check`
- `pnpm build`
- Changed file passes Prettier